### PR TITLE
 Modular: add module-info

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.openjfx.javafxplugin' version '0.0.10'
     id 'biz.aQute.bnd.builder' version '5.3.0'
     id 'com.vanniktech.maven.publish' version '0.18.0'
+    id 'org.javamodularity.moduleplugin' version '1.8.10'
 }
 
 group 'io.github.palexdev'
@@ -95,6 +96,16 @@ task removeBnd(type: Delete) {
 
 build.dependsOn removeBnd
 
+compileTestJava {
+    moduleOptions {
+        compileOnClasspath = true
+    }
+}
+
 test {
     useJUnitPlatform()
+
+    moduleOptions {
+        runOnClasspath = true
+    }
 }

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,17 @@
+module virtualizedfx {
+	requires javafx.base;
+	requires javafx.graphics;
+	requires javafx.controls;
+
+	exports io.github.palexdev.virtualizedfx;
+
+	exports io.github.palexdev.virtualizedfx.beans;
+	exports io.github.palexdev.virtualizedfx.cache;
+	exports io.github.palexdev.virtualizedfx.cell;
+	exports io.github.palexdev.virtualizedfx.collections;
+
+	exports io.github.palexdev.virtualizedfx.flow.base;
+	exports io.github.palexdev.virtualizedfx.flow.simple;
+
+	exports io.github.palexdev.virtualizedfx.utils;
+}

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,17 +1,23 @@
-module virtualizedfx {
-	requires javafx.base;
-	requires javafx.graphics;
-	requires javafx.controls;
+module VirtualizedFX {
+	requires transitive javafx.base;
+	requires transitive javafx.graphics;
+	requires transitive javafx.controls;
 
 	exports io.github.palexdev.virtualizedfx;
-
+	
+	// Beans Package
 	exports io.github.palexdev.virtualizedfx.beans;
-	exports io.github.palexdev.virtualizedfx.cache;
+	
+	// Cell Package
 	exports io.github.palexdev.virtualizedfx.cell;
+	
+	// Collections Package
 	exports io.github.palexdev.virtualizedfx.collections;
-
+	
+	// Flow Package
 	exports io.github.palexdev.virtualizedfx.flow.base;
 	exports io.github.palexdev.virtualizedfx.flow.simple;
-
+	
+	// Utils Package
 	exports io.github.palexdev.virtualizedfx.utils;
 }


### PR DESCRIPTION
Added the module-info file to make the project modular (and make MaterialFX compatible with the Java jdeps tool).

See https://github.com/palexdev/MaterialFX/issues/152