### PR TITLE
Remove OpenJFX dependencies while publishing to Maven Central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,11 @@ targetCompatibility = '11'
 javafx {
     version = '17.0.2'
     modules = ['javafx.controls', 'javafx.fxml', 'javafx.web']
+    configuration = 'compileOnly'
+}
+
+configurations {
+    testImplementation.extendsFrom compileOnly
 }
 
 dependencies {


### PR DESCRIPTION
See https://github.com/palexdev/MaterialFX/pull/168.

I can run the `Launcher` in the test directory normally. I don't know if there are any other tests that can be done.