### PR TITLE
Bug fix: grid state couldn't be updated when all rows are drawn, but there is additional space in the viewport. 

### DIFF
--- a/src/main/java/io/github/palexdev/virtualizedfx/grid/GridState.java
+++ b/src/main/java/io/github/palexdev/virtualizedfx/grid/GridState.java
@@ -94,7 +94,7 @@ public class GridState<T, C extends GridCell<T>> {
 	 * Responsible for filling the viewport the needed amount of rows/cells. So this may supply or remove
 	 * cells according to the viewport size.
 	 * <p>
-	 * If the given ranges for rows and columns are the same as the ones of the state then the old state is returned.
+	 * If the given ranges for rows and columns and viewport sizes are the same as the ones of the state then the old state is returned.
 	 * <p>
 	 * This is used by {@link GridManager#init()}.
 	 *
@@ -102,7 +102,8 @@ public class GridState<T, C extends GridCell<T>> {
 	 * a new one given the new ranges for rows and columns
 	 */
 	protected GridState<T, C> init(IntegerRange rowsRange, IntegerRange columnsRange) {
-		if (this.rowsRange.equals(rowsRange) && this.columnsRange.equals(columnsRange)) return this;
+		int maxRows = grid.getGridHelper().maxRows();
+		if (this.rowsRange.equals(rowsRange) && this.columnsRange.equals(columnsRange) && targetSize == maxRows) return this;
 
 		GridState<T, C> newState = new GridState<>(grid, rowsRange, columnsRange);
 		Set<Integer> range = IntegerRange.expandRangeToSet(rowsRange);


### PR DESCRIPTION
I use `VirtualGrid` in [my project](https://github.com/prime-slam/SOLVE). When I change cell size in a way that `maxRows` becomes bigger than `size()` (`GridState.rowsFilled()` is false), the first row is collapsed. I found that this behavior is caused by `GridState.init` method, that doesn't do anything when the given ranges for rows and columns are the same. The target size also affects rows layout in my case, so the grid state should be updated in such case too.
![56SJ8zpt1b](https://user-images.githubusercontent.com/55746901/217812344-a38634ac-98c2-43a1-8be1-25ebea0dba89.gif)
