### PR TITLE
Issues on cell size changes

### DIFF
--- a/src/main/java/io/github/palexdev/virtualizedfx/grid/GridRow.java
+++ b/src/main/java/io/github/palexdev/virtualizedfx/grid/GridRow.java
@@ -130,7 +130,7 @@ public class GridRow<T, C extends GridCell<T>> {
 			T item = grid.getItems().getElement(linear);
 			C cell;
 			if (oIndex != null) {
-				cell = cells.remove(rIndex);
+				cell = cells.remove(oIndex);
 				cell.updateItem(item);
 			} else {
 				cell = grid.getCellFactory().apply(item);

--- a/src/main/java/io/github/palexdev/virtualizedfx/grid/VirtualGrid.java
+++ b/src/main/java/io/github/palexdev/virtualizedfx/grid/VirtualGrid.java
@@ -184,11 +184,8 @@ public class VirtualGrid<T, C extends GridCell<T>> extends Control implements Vi
 		helper.computeEstimatedSize();
 
 		if (getWidth() != 0.0 && getHeight() != 0.0) {
-			if (!manager.init()) {
-				requestViewportLayout();
-			} else {
-				setPosition(0, 0);
-			}
+			manager.init();
+			requestViewportLayout();
 		}
 	}
 

--- a/src/test/java/interactive/GridTests.java
+++ b/src/test/java/interactive/GridTests.java
@@ -81,6 +81,44 @@ public class GridTests {
 	}
 
 	@Test
+	void testKeepPositionOnZoom(FxRobot robot) {
+		double width = 640;
+		double height = 480;
+		DoubleProperty scale = new SimpleDoubleProperty(1.0);
+
+		List<Color> colors = IntStream.range(0, 40)
+				.mapToObj(i -> ColorUtils.getRandomColor())
+				.toList();
+		ObservableGrid<Color> data = ObservableGrid.fromList(colors, 5);
+		VirtualGrid<Color, ScalingCell> grid = new VirtualGrid<>(
+				data,
+				c -> new ScalingCell(c, width, height, scale)
+		);
+		grid.setCellSize(Size.of(width, height));
+		scale.addListener(i -> grid.setCellSize(Size.of(
+				width * scale.get(),
+				height * scale.get()
+		)));
+
+
+		Button btn0 = new Button("-");
+		btn0.setOnAction(e -> scale.set(scale.get() / 1.15));
+		BorderPane root = new BorderPane(grid, null, null, null, btn0);
+		setupStage(root, new Size(500, 400));
+
+		grid.scrollToColumn(2);
+		grid.scrollBy(200, Orientation.HORIZONTAL);
+
+		int initialFirstColumn = grid.getGridHelper().firstColumn();
+		int initialLastColumn = grid.getGridHelper().lastColumn();
+
+		robot.clickOn(btn0);
+
+		assertEquals(initialFirstColumn, grid.getGridHelper().firstColumn());
+		assertEquals(initialLastColumn, grid.getGridHelper().lastColumn());
+	}
+
+	@Test
 	void testCorrectLayoutWithScale(FxRobot robot) {
 		double width = 595.50;
 		double height = 446.629;


### PR DESCRIPTION
Changes:

1. Fix exception, when after cell size changed, columns range shifts (for example, [2, 3] -> [3, 4]). On that line cells collection can't contain rIndex, because cells, which corresponds to any columns from the columns range was removed earlier.

2. `setPosition(0, 0)` causes a lot of problems to me (redundant frame updates). I didn't find any purpose for this behavior. I removed this line and tested in my project, and it looks fine. Could you please describe why it actually needed?